### PR TITLE
Filesystem Fallback For Desktop

### DIFF
--- a/cli-support/examples/cli.rs
+++ b/cli-support/examples/cli.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, process::Command};
 const ASSETS_FILE_LOCATION: &str = "./assets";
 
 // This is the location where the assets will be served from
-const ASSETS_SERVE_LOCATION: &str = "/assets";
+const ASSETS_SERVE_LOCATION: &str = "./assets/";
 
 fn main() {
     // First set any settings you need for the build.

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -396,7 +396,11 @@ impl FileAsset {
                 FileSource::Remote(url) => url.as_str().to_string(),
                 FileSource::Local(path) => {
                     // Tauri doesn't allow absolute paths(??) so we convert to relative.
-                    let cwd = std::env::current_dir().unwrap();
+                    let Ok(cwd) = std::env::current_dir() else {
+                        tracing::warn!("failed to get current working dir for fs fallback");
+                        return path.display().to_string();
+                    };
+
                     let path =
                         PathBuf::from(path.display().to_string().strip_prefix("\\\\?\\").unwrap());
                     let rel_path = path.strip_prefix(cwd).unwrap();

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -386,45 +386,51 @@ impl FileAsset {
         self.url_encoded
     }
 
-    /// Returns the location where the file asset will be served from
-    pub fn served_location(&self) -> String {
+    /// Returns the location where the file asset will be served from or None if the asset cannot be served
+    pub fn served_location(&self) -> Result<String, ManganisSupportError> {
         let manganis_support = std::env::var("MANGANIS_SUPPORT");
 
+        if self.url_encoded {
+            let data = self.location.read_to_bytes().unwrap();
+            let data = base64::engine::general_purpose::STANDARD_NO_PAD.encode(data);
+            let mime = self.location.source.mime_type().unwrap();
+            Ok(format!("data:{mime};base64,{data}"))
+        }
         // If manganis is being used without CLI support, we will fallback to providing a local path.
-        if manganis_support.is_err() {
+        else if manganis_support.is_err() {
             match self.location.source() {
-                FileSource::Remote(url) => url.as_str().to_string(),
+                FileSource::Remote(url) => Ok(url.as_str().to_string()),
                 FileSource::Local(path) => {
-                    let path_as_string = path.display().to_string();
+                    // If this is not the main package, we can't include assets from it without CLI support
+                    let primary_package = std::env::var("CARGO_PRIMARY_PACKAGE").is_ok();
+                    if !primary_package {
+                        return Err(ManganisSupportError::ExternalPackageCollection);
+                    }
 
                     // Tauri doesn't allow absolute paths(??) so we convert to relative.
-                    let Ok(cwd) = std::env::current_dir() else {
-                        tracing::warn!("failed to get current working dir for fs fallback");
-                        return path_as_string;
+                    let Ok(cwd) = std::env::var("CARGO_MANIFEST_DIR") else {
+                        return Err(ManganisSupportError::FailedToFindCargoManifest);
                     };
 
                     // Windows adds `\\?\` to longer path names. We'll try to remove it.
                     #[cfg(windows)]
-                    let path = PathBuf::from(
+                    let path = PathBuf::from({
+                        let path_as_string = path.display().to_string();
                         path_as_string
                             .strip_prefix("\\\\?\\")
-                            .unwrap_or(&path_as_string),
-                    );
+                            .unwrap_or(&path_as_string)
+                    });
 
                     let rel_path = path.strip_prefix(cwd).unwrap();
-                    rel_path.display().to_string()
+                    let path = PathBuf::from(".").join(rel_path);
+                    Ok(path.display().to_string())
                 }
             }
-        } else if self.url_encoded {
-            let data = self.location.read_to_bytes().unwrap();
-            let data = base64::engine::general_purpose::STANDARD_NO_PAD.encode(data);
-            let mime = self.location.source.mime_type().unwrap();
-            format!("data:{mime};base64,{data}")
         } else {
             let config = Config::current();
             let root = config.assets_serve_location();
             let unique_name = self.location.unique_name();
-            format!("{root}{unique_name}")
+            Ok(format!("{root}{unique_name}"))
         }
     }
 
@@ -485,6 +491,26 @@ impl FileAsset {
         assert!(self.location.unique_name.len() <= MAX_PATH_LENGTH);
     }
 }
+
+/// An error that can occur while collecting assets without CLI support
+#[derive(Debug)]
+pub enum ManganisSupportError {
+    /// An error that can occur while collecting assets from other packages without CLI support
+    ExternalPackageCollection,
+    /// Manganis failed to find the current package's manifest
+    FailedToFindCargoManifest,
+}
+
+impl Display for ManganisSupportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExternalPackageCollection => write!(f, "Attempted to collect assets from other packages without a CLI that supports Manganis. Please recompile with a CLI that supports Manganis like the `dioxus-cli`."),
+            Self::FailedToFindCargoManifest => write!(f, "Manganis failed to find the current package's manifest. Please recompile with a CLI that supports Manganis like the `dioxus-cli`."),
+        }
+    }
+}
+
+impl std::error::Error for ManganisSupportError {}
 
 /// A metadata asset
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]

--- a/macro/src/file.rs
+++ b/macro/src/file.rs
@@ -1,11 +1,11 @@
-use manganis_common::{AssetType, FileAsset};
+use manganis_common::{AssetType, FileAsset, ManganisSupportError};
 use quote::{quote, ToTokens};
 use syn::{parenthesized, parse::Parse};
 
 use crate::generate_link_section;
 
 pub struct FileAssetParser {
-    file_name: String,
+    file_name: Result<String, ManganisSupportError>,
     asset: AssetType,
 }
 
@@ -36,7 +36,7 @@ impl Parse for FileAssetParser {
 
 impl ToTokens for FileAssetParser {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let file_name = &self.file_name;
+        let file_name = crate::quote_path(&self.file_name);
 
         let link_section = generate_link_section(self.asset.clone());
 

--- a/macro/src/font.rs
+++ b/macro/src/font.rs
@@ -1,4 +1,4 @@
-use manganis_common::{AssetType, CssOptions, FileAsset, FileSource};
+use manganis_common::{AssetType, CssOptions, FileAsset, FileSource, ManganisSupportError};
 use quote::{quote, ToTokens};
 use syn::{bracketed, parenthesized, parse::Parse};
 
@@ -135,7 +135,7 @@ impl Parse for ParseFontOptions {
 }
 
 pub struct FontAssetParser {
-    file_name: String,
+    file_name: Result<String, ManganisSupportError>,
     asset: AssetType,
 }
 
@@ -168,7 +168,7 @@ impl Parse for FontAssetParser {
 
 impl ToTokens for FontAssetParser {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let file_name = &self.file_name;
+        let file_name = crate::quote_path(&self.file_name);
 
         let link_section = generate_link_section(self.asset.clone());
 

--- a/macro/src/image.rs
+++ b/macro/src/image.rs
@@ -1,3 +1,4 @@
+use manganis_common::ManganisSupportError;
 use manganis_common::{AssetType, FileAsset, FileOptions, FileSource, ImageOptions};
 use quote::{quote, ToTokens};
 use syn::{parenthesized, parse::Parse, Token};
@@ -159,7 +160,7 @@ enum ImageType {
 }
 
 pub struct ImageAssetParser {
-    file_name: String,
+    file_name: Result<String, ManganisSupportError>,
     low_quality_preview: Option<String>,
     asset: AssetType,
 }
@@ -297,7 +298,7 @@ fn url_encoded_asset(file_asset: &FileAsset) -> Result<String, syn::Error> {
 
 impl ToTokens for ImageAssetParser {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let file_name = &self.file_name;
+        let file_name = crate::quote_path(&self.file_name);
         let low_quality_preview = match &self.low_quality_preview {
             Some(lqip) => quote! { Some(#lqip) },
             None => quote! { None },

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -245,3 +245,21 @@ pub fn meta(input: TokenStream) -> TokenStream {
     .into_token_stream()
     .into()
 }
+
+fn quote_path(path: &Result<String, manganis_common::ManganisSupportError>) -> TokenStream2 {
+    match path {
+        Ok(path) => quote! { #path },
+        Err(err) => {
+            // Expand the error into a warning and return an empty path. Manganis should try not fail to compile the application because it may be checked in CI where manganis CLI support is not available.
+            let err = err.to_string();
+            quote! {
+                {
+                    #[deprecated(note = #err)]
+                    struct ManganisSupportError;
+                    _ = ManganisSupportError;
+                    ""
+                }
+            }
+        }
+    }
+}

--- a/test-package/src/main.rs
+++ b/test-package/src/main.rs
@@ -31,11 +31,15 @@ fn main() {
     tracing_subscriber::fmt::init();
 
     let cwd = std::env::current_dir().unwrap();
+    println!("{:?}", cwd);
 
     // Make sure the macro paths match with the paths that actually exist
     for path in ALL_ASSETS {
-        let path = cwd.join(format!(".{path}"));
-        println!("{}", path.display());
-        assert!(path.exists());
+        // let path = cwd.join(format!(".{path}"));
+        // let path = cwd.join(path);
+        println!("{:?}", path);
+        let path = cwd.join(path);
+        println!("{:?}", path);
+        println!("{:?}", path.exists());
     }
 }

--- a/test-package/src/main.rs
+++ b/test-package/src/main.rs
@@ -1,5 +1,7 @@
 // The assets must be configured with the [CLI](cli-support/examples/cli.rs) before this example can be run.
 
+use std::path::PathBuf;
+
 use test_package_dependency::{
     AVIF_ASSET, COMFORTAA_FONT, CSS_ASSET, HTML_ASSET, IMAGE_ASSET, JPEG_ASSET, PNG_ASSET,
     RESIZED_AVIF_ASSET, RESIZED_JPEG_ASSET, RESIZED_PNG_ASSET, RESIZED_WEBP_ASSET, ROBOTO_FONT,
@@ -30,16 +32,12 @@ const ALL_ASSETS: &[&str] = &[
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let cwd = std::env::current_dir().unwrap();
-    println!("{:?}", cwd);
+    let external_paths_should_exist: bool = option_env!("MANGANIS_SUPPORT").is_some();
 
     // Make sure the macro paths match with the paths that actually exist
     for path in ALL_ASSETS {
-        // let path = cwd.join(format!(".{path}"));
-        // let path = cwd.join(path);
+        let path = PathBuf::from(path);
         println!("{:?}", path);
-        let path = cwd.join(path);
-        println!("{:?}", path);
-        println!("{:?}", path.exists());
+        assert!(!external_paths_should_exist || path.exists());
     }
 }


### PR DESCRIPTION
Adds filesystem fallback for the desktop platform. This allows examples to be ran without the `dx` CLI. 

We check if the `MANGANIS_SUPPORT` env variable exists and if not, we provide the relative filesystem path to the application.

This needs some testing:
- [x] Windows
- [x] Linux
- [x] Mac

Simply `cargo run` a Dioxus desktop app that uses Manganis and check if the asset was correctly included.