### PR TITLE
Only preload css in the head; don't load css automatically

### DIFF
--- a/cli-support/tests/collects_assets.rs
+++ b/cli-support/tests/collects_assets.rs
@@ -26,10 +26,10 @@ fn collects_assets() {
     };
 
     // Check if rustc is trying to link
-    if command == "build" {
-        build();
-    } else if command == "link" {
+    if command == "link" {
         link();
+    } else {
+        build();
     }
 }
 

--- a/common/src/file.rs
+++ b/common/src/file.rs
@@ -201,6 +201,8 @@ impl FromStr for ImageType {
 pub struct VideoOptions {
     /// Whether the video should be compressed
     compress: bool,
+    /// Whether the video should be preloaded
+    preload: bool,
     /// The type of the video
     ty: VideoType,
 }
@@ -211,6 +213,9 @@ impl Display for VideoOptions {
         if self.compress {
             write!(f, " (compressed)")?;
         }
+        if self.preload {
+            write!(f, " (preload)")?;
+        }
         Ok(())
     }
 }
@@ -218,7 +223,11 @@ impl Display for VideoOptions {
 impl VideoOptions {
     /// Creates a new video options struct
     pub fn new(ty: VideoType) -> Self {
-        Self { compress: true, ty }
+        Self {
+            compress: true,
+            ty,
+            preload: false,
+        }
     }
 
     /// Returns the type of the video
@@ -239,6 +248,16 @@ impl VideoOptions {
     /// Sets whether the video should be compressed
     pub fn set_compress(&mut self, compress: bool) {
         self.compress = compress;
+    }
+
+    /// Returns whether the video should be preloaded
+    pub fn preload(&self) -> bool {
+        self.preload
+    }
+
+    /// Sets whether the video should be preloaded
+    pub fn set_preload(&mut self, preload: bool) {
+        self.preload = preload;
     }
 }
 
@@ -312,6 +331,13 @@ impl Display for FontType {
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone, Hash)]
 pub struct CssOptions {
     minify: bool,
+    preload: bool,
+}
+
+impl Default for CssOptions {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Display for CssOptions {
@@ -319,25 +345,40 @@ impl Display for CssOptions {
         if self.minify {
             write!(f, "minified")?;
         }
+        if self.preload {
+            write!(f, " (preload)")?;
+        }
         Ok(())
     }
 }
 
 impl CssOptions {
     /// Creates a new css options struct
-    pub fn new(minify: bool) -> Self {
-        Self { minify }
+    pub const fn new() -> Self {
+        Self {
+            minify: true,
+            preload: false,
+        }
     }
 
     /// Returns whether the css should be minified
     pub fn minify(&self) -> bool {
         self.minify
     }
-}
 
-impl Default for CssOptions {
-    fn default() -> Self {
-        Self { minify: true }
+    /// Sets whether the css should be minified
+    pub fn set_minify(&mut self, minify: bool) {
+        self.minify = minify;
+    }
+
+    /// Returns whether the css should be preloaded
+    pub fn preload(&self) -> bool {
+        self.preload
+    }
+
+    /// Sets whether the css should be preloaded
+    pub fn set_preload(&mut self, preload: bool) {
+        self.preload = preload;
     }
 }
 

--- a/common/src/manifest.rs
+++ b/common/src/manifest.rs
@@ -24,11 +24,13 @@ impl AssetManifest {
         for asset in &self.assets {
             if let crate::AssetType::File(file) = asset {
                 match file.options() {
-                    crate::FileOptions::Css(_) => {
-                        let asset_path = file.served_location();
-                        head.push_str(&format!(
-                            "<link rel=\"stylesheet\" href=\"{asset_path}\">\n"
-                        ))
+                    crate::FileOptions::Css(css_options) => {
+                        if css_options.preload() {
+                            let asset_path = file.served_location();
+                            head.push_str(&format!(
+                                "<link rel=\"preload\" as=\"style\" href=\"{asset_path}\">\n"
+                            ))
+                        }
                     }
                     crate::FileOptions::Image(image_options) => {
                         if image_options.preload() {

--- a/macro/src/css.rs
+++ b/macro/src/css.rs
@@ -1,0 +1,191 @@
+use manganis_common::{AssetType, CssOptions, FileAsset, FileOptions, FileSource};
+use quote::{quote, ToTokens};
+use syn::{parenthesized, parse::Parse, LitBool};
+
+use crate::generate_link_section;
+
+struct ParseCssOptions {
+    options: Vec<ParseCssOption>,
+}
+
+impl ParseCssOptions {
+    fn apply_to_options(self, file: &mut FileAsset) {
+        for option in self.options {
+            option.apply_to_options(file);
+        }
+    }
+}
+
+impl Parse for ParseCssOptions {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut options = Vec::new();
+        while !input.is_empty() {
+            options.push(input.parse::<ParseCssOption>()?);
+        }
+        Ok(ParseCssOptions { options })
+    }
+}
+
+enum ParseCssOption {
+    UrlEncoded(bool),
+    Preload(bool),
+    Minify(bool),
+}
+
+impl ParseCssOption {
+    fn apply_to_options(self, file: &mut FileAsset) {
+        match self {
+            ParseCssOption::Preload(_) | ParseCssOption::Minify(_) => {
+                file.with_options_mut(|options| {
+                    if let FileOptions::Css(options) = options {
+                        match self {
+                            ParseCssOption::Minify(format) => {
+                                options.set_minify(format);
+                            }
+                            ParseCssOption::Preload(preload) => {
+                                options.set_preload(preload);
+                            }
+                            _ => {}
+                        }
+                    }
+                })
+            }
+            ParseCssOption::UrlEncoded(url_encoded) => {
+                file.set_url_encoded(url_encoded);
+            }
+        }
+    }
+}
+
+impl Parse for ParseCssOption {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let _ = input.parse::<syn::Token![.]>()?;
+        let ident = input.parse::<syn::Ident>()?;
+        let content;
+        parenthesized!(content in input);
+        match ident.to_string().as_str() {
+            "preload" => {
+                Ok(ParseCssOption::Preload(true))
+            }
+            "url_encoded" => {
+                Ok(ParseCssOption::UrlEncoded(true))
+            }
+            "minify" => {
+                Ok(ParseCssOption::Minify(content.parse::<LitBool>()?.value()))
+            }
+            _ => Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "Unknown Css option: {}. Supported options are preload, url_encoded, and minify",
+                    ident
+                ),
+            )),
+        }
+    }
+}
+
+pub struct CssAssetParser {
+    file_name: String,
+    asset: AssetType,
+}
+
+impl Parse for CssAssetParser {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let inside;
+        parenthesized!(inside in input);
+        let path = inside.parse::<syn::LitStr>()?;
+
+        let parsed_options = {
+            if input.is_empty() {
+                None
+            } else {
+                Some(input.parse::<ParseCssOptions>()?)
+            }
+        };
+
+        let path_as_str = path.value();
+        let path: FileSource = match path_as_str.parse() {
+            Ok(path) => path,
+            Err(e) => {
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    format!("{e}"),
+                ))
+            }
+        };
+        let mut this_file = FileAsset::new(path.clone())
+            .with_options(manganis_common::FileOptions::Css(CssOptions::new()));
+        if let Some(parsed_options) = parsed_options {
+            parsed_options.apply_to_options(&mut this_file);
+        }
+
+        let asset = manganis_common::AssetType::File(this_file.clone());
+
+        let file_name = if this_file.url_encoded() {
+            #[cfg(not(feature = "url-encoding"))]
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "URL encoding is not enabled. Enable the url-encoding feature to use this feature",
+            ));
+            #[cfg(feature = "url-encoding")]
+            url_encoded_asset(&this_file).map_err(|e| {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    format!("Failed to encode file: {}", e),
+                )
+            })?
+        } else {
+            this_file.served_location()
+        };
+
+        Ok(CssAssetParser { file_name, asset })
+    }
+}
+
+#[cfg(feature = "url-encoding")]
+fn url_encoded_asset(file_asset: &FileAsset) -> Result<String, syn::Error> {
+    use base64::Engine;
+
+    let target_directory =
+        std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+    let output_folder = std::path::Path::new(&target_directory)
+        .join("manganis")
+        .join("assets");
+    std::fs::create_dir_all(&output_folder).map_err(|e| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("Failed to create output folder: {}", e),
+        )
+    })?;
+    manganis_cli_support::process_file(file_asset, &output_folder).map_err(|e| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("Failed to process file: {}", e),
+        )
+    })?;
+    let file = output_folder.join(file_asset.location().unique_name());
+    let data = std::fs::read(file).map_err(|e| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("Failed to read file: {}", e),
+        )
+    })?;
+    let data = base64::engine::general_purpose::STANDARD_NO_PAD.encode(data);
+    let mime = manganis_common::get_mime_from_ext(file_asset.options().extension());
+    Ok(format!("data:{mime};base64,{data}"))
+}
+
+impl ToTokens for CssAssetParser {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let file_name = &self.file_name;
+
+        let link_section = generate_link_section(self.asset.clone());
+
+        tokens.extend(quote! {
+            {
+                #link_section
+                #file_name
+            }
+        })
+    }
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+use css::CssAssetParser;
 use file::FileAssetParser;
 use font::FontAssetParser;
 use image::ImageAssetParser;
@@ -14,6 +15,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use syn::{parse::Parse, parse_macro_input, LitStr};
 
+mod css;
 mod file;
 mod font;
 mod image;
@@ -167,6 +169,7 @@ enum AnyAssetParser {
     File(FileAssetParser),
     Image(ImageAssetParser),
     Font(FontAssetParser),
+    Css(CssAssetParser),
 }
 
 impl Parse for AnyAssetParser {
@@ -178,11 +181,12 @@ impl Parse for AnyAssetParser {
             "file" => Self::File(input.parse::<FileAssetParser>()?),
             "image" => Self::Image(input.parse::<ImageAssetParser>()?),
             "font" => Self::Font(input.parse::<FontAssetParser>()?),
+            "css" => Self::Css(input.parse::<CssAssetParser>()?),
             _ => {
                 return Err(syn::Error::new(
                     proc_macro2::Span::call_site(),
                     format!(
-                        "Unknown asset type: {as_string}. Supported types are file, image, font"
+                        "Unknown asset type: {as_string}. Supported types are file, image, font, and css"
                     ),
                 ))
             }
@@ -201,6 +205,9 @@ impl ToTokens for AnyAssetParser {
             }
             Self::Font(font) => {
                 font.to_tokens(tokens);
+            }
+            Self::Css(css) => {
+                css.to_tokens(tokens);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl ImageAssetBuilder {
     ///
     /// > **Note**: This will do nothing outside of the `mg!` macro
     ///
-    /// The choosing the right format can make your site load much faster. Webp and avif images tend to be a good default for most images
+    /// Choosing the right format can make your site load much faster. Webp and avif images tend to be a good default for most images
     ///
     /// ```rust
     /// const _: manganis::ImageAsset = manganis::mg!(image("https://avatars.githubusercontent.com/u/79236386?s=48&v=4").format(ImageType::Webp));
@@ -184,6 +184,72 @@ impl ImageAssetBuilder {
 #[allow(unused)]
 pub const fn image(path: &'static str) -> ImageAssetBuilder {
     ImageAssetBuilder
+}
+
+/// A builder for a css asset. This must be used in the [`mg!`] macro.
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
+pub struct CssAssetBuilder;
+
+impl CssAssetBuilder {
+    /// Sets whether the css should be minified (default: true)
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// Minifying the css can make your site load faster by loading less data
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(css("https://sindresorhus.com/github-markdown-css/github-markdown.css").minify(false));
+    /// ```
+    #[allow(unused)]
+    pub const fn minify(self, minify: bool) -> Self {
+        Self
+    }
+
+    /// Make the css preloaded
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// Preloading css will make the css start to load as soon as possible. This is useful for css that will be displayed soon after the page loads or css that may not be visible immediately, but should start loading sooner
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(css("https://sindresorhus.com/github-markdown-css/github-markdown.css").preload());
+    /// ```
+    #[allow(unused)]
+    pub const fn preload(self) -> Self {
+        Self
+    }
+
+    /// Make the css URL encoded
+    ///
+    /// > **Note**: This will do nothing outside of the `mg!` macro
+    ///
+    /// URL encoding an image inlines the data of the css into the URL. This is useful for small css files that should load as soon as the html is parsed
+    ///
+    /// ```rust
+    /// const _: &str = manganis::mg!(css("https://sindresorhus.com/github-markdown-css/github-markdown.css").url_encoded());
+    /// ```
+    #[allow(unused)]
+    pub const fn url_encoded(self) -> Self {
+        Self
+    }
+}
+
+/// Create an css asset from the local path or url to the css
+///
+/// > **Note**: This will do nothing outside of the `mg!` macro
+///
+/// You can collect css which will be automatically minified with the css builder:
+/// ```rust
+/// const _: &str = manganis::mg!(css("https://sindresorhus.com/github-markdown-css/github-markdown.css"));
+/// ```
+/// You can mark css as preloaded to make them load faster in your app:
+/// ```rust
+/// const _: &str = manganis::mg!(css("https://sindresorhus.com/github-markdown-css/github-markdown.css").preload());
+/// ```
+#[allow(unused)]
+pub const fn css(path: &'static str) -> CssAssetBuilder {
+    CssAssetBuilder
 }
 
 /// A builder for a font asset. This must be used in the `mg!` macro.


### PR DESCRIPTION
Now that dioxus supports loading css in the head with the `head::Link` and `Style` components, we don't need to auto inject css into the head. This should also make manganis more portable for other builds tools like trunk

Closes #36 