### PR TITLE
Update Cargo.toml to point to correct repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Evan Almloff"]
 edition = "2021"
 description = "Ergonomic, automatic, cross crate asset collection and optimization"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/DioxusLabs/dioxus/"
+repository = "https://github.com/DioxusLabs/manganis/"
 homepage = "https://dioxuslabs.com"
 keywords = ["assets"]
 


### PR DESCRIPTION
https://docs.rs/manganis/latest/manganis currently links to https://github.com/DioxusLabs/dioxus when it should link to https://github.com/DioxusLabs/manganis