### PR TITLE
Fix linker intercept issue on NixOS

### DIFF
--- a/cli-support/src/linker_intercept.rs
+++ b/cli-support/src/linker_intercept.rs
@@ -142,7 +142,7 @@ fn create_linker_script(exec: PathBuf, subcommand: &str) -> Result<PathBuf, std:
     );
     #[cfg(not(windows))]
     let (script, ext) = (
-        format!("#!/bin/bash\n{} {} $@", exec.display(), subcommand),
+        format!("#!/usr/bin/env bash\n{} {} $@", exec.display(), subcommand),
         "sh",
     );
 


### PR DESCRIPTION
Basically this: https://discourse.nixos.org/t/add-bin-bash-to-avoid-unnecessary-pain/5673

It looks like `/bin/sh` is also available, which appears to have been added for POSIX compliance. Maybe you could switch to that? It doesn't look like the generated script requires any special bash features.