### PR TITLE
include the manganis-common version in the file name hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,9 @@ name = "built"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
+dependencies = [
+ "git2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -855,6 +858,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1327,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1467,7 @@ version = "0.2.4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
+ "built",
  "home",
  "infer",
  "reqwest",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,3 +26,6 @@ tracing = "0.1.40"
 
 [features]
 html = []
+
+[build-dependencies]
+built = { version = "0.7", features = ["git2"] }

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -483,10 +483,13 @@ impl FileAsset {
         if file_name.len() + extension_and_hash_size > MAX_PATH_LENGTH {
             file_name = file_name[..MAX_PATH_LENGTH - extension_and_hash_size].to_string();
         }
+        // Generate an unique name for the file based on the options, source, and the current version of manganis
         let mut hash = std::collections::hash_map::DefaultHasher::new();
         updated.hash(&mut hash);
         self.options.hash(&mut hash);
         self.location.source.hash(&mut hash);
+        crate::built::PKG_VERSION.hash(&mut hash);
+        crate::built::GIT_COMMIT_HASH.hash(&mut hash);
         let uuid = hash.finish();
         self.location.unique_name = format!("{file_name}{uuid:x}{extension}");
         assert!(self.location.unique_name.len() <= MAX_PATH_LENGTH);

--- a/common/src/built.rs
+++ b/common/src/built.rs
@@ -1,0 +1,2 @@
+// The file `built.rs` was placed there by cargo and `build.rs`
+include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@
 //! Common types and methods for the manganis asset system
 
 mod asset;
+mod built;
 pub mod cache;
 mod config;
 mod file;


### PR DESCRIPTION
This PR adds the version of manganis to the file hash we use for caching. This invalidates the cached files when we update manganis