### PR TITLE
Don't allow libraries to preload at compile time

### DIFF
--- a/macro/src/css.rs
+++ b/macro/src/css.rs
@@ -67,6 +67,7 @@ impl Parse for ParseCssOption {
         parenthesized!(content in input);
         match ident.to_string().as_str() {
             "preload" => {
+                crate::verify_preload_valid(&ident)?;
                 Ok(ParseCssOption::Preload(true))
             }
             "url_encoded" => {

--- a/macro/src/image.rs
+++ b/macro/src/image.rs
@@ -82,6 +82,7 @@ impl Parse for ParseImageOption {
                 Ok(ParseImageOption::Size((size.width, size.height)))
             }
             "preload" => {
+                crate::verify_preload_valid(&ident)?;
                 Ok(ParseImageOption::Preload(true))
             }
             "url_encoded" => {

--- a/macro/src/js.rs
+++ b/macro/src/js.rs
@@ -66,7 +66,10 @@ impl Parse for ParseJsOption {
         let content;
         parenthesized!(content in input);
         match ident.to_string().as_str() {
-            "preload" => Ok(ParseJsOption::Preload(true)),
+            "preload" => {
+                crate::verify_preload_valid(&ident)?;
+                Ok(ParseJsOption::Preload(true))
+            }
             "url_encoded" => Ok(ParseJsOption::UrlEncoded(true)),
             "minify" => Ok(ParseJsOption::Minify(content.parse::<LitBool>()?.value())),
             _ => Err(syn::Error::new(

--- a/macro/src/json.rs
+++ b/macro/src/json.rs
@@ -53,7 +53,10 @@ impl Parse for ParseJsonOption {
         let _content;
         parenthesized!(_content in input);
         match ident.to_string().as_str() {
-            "preload" => Ok(ParseJsonOption::Preload(true)),
+            "preload" => {
+                crate::verify_preload_valid(&ident)?;
+                Ok(ParseJsonOption::Preload(true))
+            },
             "url_encoded" => Ok(ParseJsonOption::UrlEncoded(true)),
             _ => Err(syn::Error::new(
                 proc_macro2::Span::call_site(),

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -368,3 +368,16 @@ pub(crate) fn url_encoded_asset(file_asset: &FileAsset) -> Result<String, syn::E
     let mime = manganis_common::get_mime_from_ext(file_asset.options().extension());
     Ok(format!("data:{mime};base64,{data}"))
 }
+
+pub(crate) fn verify_preload_valid(ident: &Ident) -> Result<(), syn::Error> {
+    // Compile time preload is only supported for the primary package
+    if std::env::var("CARGO_PRIMARY_PACKAGE").is_err() {
+        return Err(syn::Error::new(
+            ident.span(),
+            "The `preload` option is only supported for the primary package. Libraries should not preload assets or should preload assets\
+            at runtime with utilities your framework provides",
+        ));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR removes the `preload` option for libraries. Preloading all assets in libraries may cause too many assets to be loaded. If an asset defined in a library should be preloaded, it should be decided by the caller