### PR TITLE
Make absolute links relative to the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ pub const fn font() -> FontAssetBuilder {
 ///
 /// The file builder collects an arbitrary file. Relative paths are resolved relative to the package root
 /// ```rust
-/// const _: &str = manganis::mg!("src/asset.txt");
+/// const _: &str = manganis::mg!("/assets/asset.txt");
 /// ```
 /// Or you can use URLs to read the asset at build time from a remote location
 /// ```rust

--- a/test-package/src/main.rs
+++ b/test-package/src/main.rs
@@ -8,7 +8,7 @@ use test_package_dependency::{
     ROBOTO_FONT_LIGHT_FONT, SCRIPT, TEXT_ASSET, WEBP_ASSET,
 };
 
-const TEXT_FILE: &str = manganis::mg!("./test-package-dependency/src/asset.txt");
+const TEXT_FILE: &str = manganis::mg!("/test-package-dependency/src/asset.txt");
 
 const ALL_ASSETS: &[&str] = &[
     TEXT_FILE,


### PR DESCRIPTION
Absolute paths will not work in bundled libraries/applications. This PR interprets absolute paths as relative to the crate root instead