### PR TITLE
Bump common version

### DIFF
--- a/cli-support/Cargo.toml
+++ b/cli-support/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["assets"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-manganis-common = { path = "../common", version = "0.3.0-alpha.1" }
+manganis-common = { path = "../common", version = "0.3.0-alpha.2" }
 
 serde = { version = "1.0.183", features = ["derive"] }
-serde_json = {version="1.0.116"}
+serde_json = { version = "1.0.116" }
 anyhow = "1"
 rayon = "1.7.0"
 rustc-hash = "1.1.0"
@@ -25,7 +25,9 @@ railwind = "0.1.5"
 
 # Image compression/conversion
 # JPEG
-mozjpeg = { version = "0.10.7", default-features = false, features = ["parallel"] }
+mozjpeg = { version = "0.10.7", default-features = false, features = [
+    "parallel",
+] }
 # PNG
 imagequant = "4.2.0"
 png = "0.17.9"
@@ -64,7 +66,9 @@ swc_ecma_lints = { version = "=0.100.0", default-features = false }
 swc_ecma_loader = { version = "=0.49.1", default-features = false }
 swc_ecma_minifier = { version = "=0.204.0", default-features = false }
 swc_ecma_parser = { version = "=0.149.1", default-features = false }
-swc_ecma_preset_env = { version = "=0.217.0", default-features = false, features = ["serde"] }
+swc_ecma_preset_env = { version = "=0.217.0", default-features = false, features = [
+    "serde",
+] }
 swc_ecma_transforms = { version = "=0.239.0", default-features = false }
 swc_ecma_transforms_base = { version = "=0.145.0", default-features = false }
 swc_ecma_transforms_classes = { version = "=0.134.0", default-features = false }
@@ -95,7 +99,7 @@ reqwest = { version = "0.12.5", features = ["blocking"] }
 tracing = "0.1.37"
 
 # Extracting data from an executable
-object = {version="0.36.0", features=["wasm"]}
+object = { version = "0.36.0", features = ["wasm"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -16,14 +16,14 @@ proc-macro = true
 proc-macro2 = { version = "1.0" }
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-manganis-common = { path = "../common", version = "0.3.0-alpha.1" }
-manganis-cli-support = { path = "../cli-support", version = "0.3.0-alpha.1", optional = true }
+manganis-common = { path = "../common", version = "0.3.0-alpha.2" }
+manganis-cli-support = { path = "../cli-support", version = "0.3.0-alpha.2", optional = true }
 base64 = { version = "0.21.5", optional = true }
 tracing-subscriber = "0.3.18"
 serde_json = "1.0"
 
 [build-dependencies]
-manganis-common = { path = "../common", version = "0.3.0-alpha.1" }
+manganis-common = { path = "../common", version = "0.3.0-alpha.2" }
 
 [features]
 url-encoding = ["manganis-cli-support", "base64"]


### PR DESCRIPTION

This PR: https://github.com/DioxusLabs/manganis/pull/63 was aimed at resolving issues compiling to wasm due to ``tokio`` being pulled in as a dependency of ``reqwest``, with features that are not compatible with wasm.

This PR did not bump the dependency of ``common`` from the macros crate. As a result, the macros crate incorrectly pulls the alpha1 release, which includes tokio.

```
mio v1.0.2
├── tokio v1.39.2
│   ├── h2 v0.4.5
│   │   ├── hyper v1.4.1
│   │   │   ├── hyper-tls v0.6.0
│   │   │   │   └── reqwest v0.12.5
│   │   │   │       └── manganis-common v0.3.0-alpha.1
│   │   │   │           └── manganis-macro v0.3.0-alpha.1 (proc-macro)
```

This can be seen by pulling in ``manganis v0.3.0-alpha2`` and running ``cargo tree -i mio`` (the problematic dependency).
I might suggest going forward that the version field is dropped from the dependency entirely, so it always pulls in the latest sister crates.

I am happy to amend my PR to make this change if desired. Thank you for all your time and hard work placed in dioxus!
